### PR TITLE
Fix for flickering output in np widget

### DIFF
--- a/src/am.sh
+++ b/src/am.sh
@@ -1,5 +1,9 @@
 #!/bin/zsh
 np(){
+	# clear the screen first
+	clear
+  # hide the cursor (as we will later use this refresh the screen)
+  printf '\e[?25l'
 	init=1
 	help='false'
 	while :
@@ -92,7 +96,11 @@ r                       Toggle song repeat
 		prog=${progressBars:0:$percentRemain}
 		if [ "$1" = "-t" ]
 		then
-			clear
+			
+			# Move the cursor to the top of the screen
+		  # (instead of clearing to avoid flickering)
+	    printf '\033[;H'       
+
 			paste <(printf '%s\n' "$name" "$artist - $record" "$shuffleIcon $repeatIcon $(echo $currMin:$currSec ${cyan}${prog}${nocolor}${progBG} $endMin:$endSec)" "$volIcon $(echo "${magenta}$vol${nocolor}$volBG")") 
 		else
 			paste <(printf %s "$art") <(printf %s "") <(printf %s "") <(printf %s "") <(printf '%s\n' "$name" "$artist - $record" "$shuffleIcon $repeatIcon $(echo $currMin:$currSec ${cyan}${prog}${nocolor}${progBG} $endMin:$endSec)" "$volIcon $(echo "${magenta}$vol${nocolor}$volBG")") 


### PR DESCRIPTION
By issuing the 'clear' command, depending on the terminal implementation, the screen can flicker if the terminal takes some time to draw the next characters.

The correct fix is not to clear the screen, but instead to manipulate the cursor to place it at the top, then simply re-draw. This avoids any flickering in the output.

This fix should address that for the terminal player.


Thanks again for making such a great, simple tool. It was easy to make this change.
